### PR TITLE
Option to show error codes in failed reCAPTCHA response

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can clone the [github repo](https://github.com/dakiquang/yiiReCaptcha) and g
 
 * 2/ [Sign up for an reCAPTCHA API keys on Google reCaptcha](https://www.google.com/recaptcha/admin#createsite). and get the key/secret pair
 
-* 3/ Configure this component in your configuration file (main.php file). The parameters siteKey and secret are required. If you are using as an extension, the <path-to-destination-folder> should be 'application.extensions'. The option showResponseErrors can be set to true to see the reCAPTCHA error codes returned in a failed API request.
+* 3/ Configure this component in your configuration file (main.php file). The parameters siteKey and secret are required. If you are using as an extension, the &lt;path-to-destination-folder&gt; should be 'application.extensions'. The option showResponseErrors can be set to true to see the reCAPTCHA error codes returned in a failed API request.
 
 ```php
 'components' => [

--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ You can clone the [github repo](https://github.com/dakiquang/yiiReCaptcha) and g
 
 * 2/ [Sign up for an reCAPTCHA API keys on Google reCaptcha](https://www.google.com/recaptcha/admin#createsite). and get the key/secret pair
 
-* 3/ Configure this component in your configuration file (main.php file). The parameters siteKey and secret are required.
+* 3/ Configure this component in your configuration file (main.php file). The parameters siteKey and secret are required. If you are using as an extension, the <path-to-destination-folder> should be 'application.extensions'. The option showResponseErrors can be set to true to see the reCAPTCHA error codes returned in a failed API request.
 
 ```php
 'components' => [
     'reCaptcha' => [
         'name' => 'reCaptcha',
-        'class' => '<path-to-destination-folder>\yiiReCaptcha\ReCaptcha',
+        'class' => '<path-to-destination-folder>.yiiReCaptcha.ReCaptcha',
         'key' => '<your-key>',
         'secret' => '<your-secret>',
+        'showResponseErrors' => False,
     ],
     ...
 ```

--- a/ReCaptcha.php
+++ b/ReCaptcha.php
@@ -28,6 +28,9 @@ class ReCaptcha extends CInputWidget
 
     /** @var if you might have a large number of hosted domains and would like to have one key working on all of them - the solution is the secure token. */
     public $isSecureToken = false;
+    
+    /** @var bool Show error codes from ReCAPTCHA API request in validation response */
+    public $showResponseErrors = false;
 
     public function init()
     {

--- a/ReCaptchaValidator.php
+++ b/ReCaptchaValidator.php
@@ -41,7 +41,7 @@ class ReCaptchaValidator extends CValidator
             }
         }
         if ($this->message === null || empty($this->message)) {
-            $this->message = Yii::t('yii', 'An error occurred when attempting to verify your ReCAPTCHA.');
+            $this->message = Yii::t('yii', 'An error occurred when attempting to verify your reCAPTCHA.');
         }
     }
 
@@ -74,13 +74,12 @@ class ReCaptchaValidator extends CValidator
         );
         $response = $this->getResponse($request);
         
-        // Success
+        // Errors
         if (!isset($response['success'])) {
             throw new CException('Invalid recaptcha verify response.');
         }
-        // Error
         if (!$response['success']) {
-            $message = Yii::t('yii', 'ReCAPTCHA was not able to verify you.');
+            $message = Yii::t('yii', 'reCAPTCHA was not able to verify you.');
             // Add error codes from API response to validation error message.
             if (Yii::app()->reCaptcha->showResponseErrors){
                 if (isset($response['error-codes']) && is_array($response['error-codes'])){


### PR DESCRIPTION
I kept getting an error when testing the reCAPTCHA, but had no clue as to what it was. I've added an additional option that will display the error codes returned from the reCAPTCHA API request, in the validation error message.